### PR TITLE
fix: the app_fs_init.sh is not functioning as expected for make builds (tested for libraries)

### DIFF
--- a/src/app_config.py
+++ b/src/app_config.py
@@ -299,6 +299,25 @@ class AppConfig:
             stream.write(content)
         os.chmod(os.path.join(test_dir, "app_fs_init.sh"), 0o755)
 
+        try:
+            print("Running app_fs_init.sh")
+            result = subprocess.run(["bash", os.path.join(test_dir, "app_fs_init.sh")],
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE,
+                                        text=True)
+            if result.stderr:
+                print(f"Error: {result.stderr}", file=sys.stderr)
+        except subprocess.CalledProcessError as e:
+            print(f"Error running app_fs_init.sh: {e}", file=sys.stderr)
+
+        if os.path.exists(os.path.join(test_dir, "app_fs_init.sh")):
+            print(f"Initialized application filesystem initrd.cpio is stored in {app_dir}/initrd.cpio")
+            self.initrd_cpio_path = os.path.join(app_dir, "initrd.cpio")
+        else:
+            print(f"Failed to initialize application filesystem in {test_dir}/app_fs_init.sh", file=sys.stderr)
+        
+        return 0 if self.initrd_cpio_path is None else 1, self.initrd_cpio_path
+
     def __init__(self, app_config=".app/Kraftfile", user_config="config.yaml"):
         """Initialize application configuration.
 
@@ -309,6 +328,7 @@ class AppConfig:
         self.config = {}
         self._parse_user_config(user_config)
         self._parse_app_config(app_config)
+        self.initrd_cpio_path = None
 
     def __str__(self):
         return str(self.config)

--- a/src/build_setup.py
+++ b/src/build_setup.py
@@ -4,6 +4,7 @@ THis module provides the BuildSetup class, which manages the build setup.
 
 import os
 import logging
+import subprocess
 
 from constants import SCRIPT_DIR
 
@@ -283,6 +284,19 @@ class BuildSetup:
         with open(os.path.join(self.dir, "build"), "w", encoding="utf-8") as stream:
             stream.write(content)
         os.chmod(os.path.join(self.dir, "build"), 0o755)
+
+        if os.path.exists(self.app_config.initrd_cpio_path):
+            print(f"Rootfs cpio file {self.app_config.initrd_cpio_path} is copied to the {target_dir}")
+            result = subprocess.run(
+                ["cp", self.app_config.initrd_cpio_path, target_dir]
+            )
+            if result.returncode != 0:
+                logging.error(
+                    f"Failed to copy initrd cpio file from {self.app_config.initrd_cpio_path} to {target_dir}"
+                )
+
+        
+
 
     def _generate_build_kraft(self):
         """Generate build script for Kraft-based build."""

--- a/src/build_setup.py
+++ b/src/build_setup.py
@@ -294,7 +294,10 @@ class BuildSetup:
                 logging.error(
                     f"Failed to copy initrd cpio file from {self.app_config.initrd_cpio_path} to {target_dir}"
                 )
-
+        else:
+            raise FileNotFoundError(
+                f"Initrd cpio file {self.app_config.initrd_cpio_path} does not exist."
+            )
         
 
 


### PR DESCRIPTION
The app_fs_inti.sh file is not creating the roofs beforehand as expected.

Changes:

1. Initiate the `app_fs_init.sh` beforehand as a fixture.
   - This step is done on the AppConfig when the app_fs_inited.sh file is generated from its template.
2. Copy the initrd.cpio to each of the make build directories for the kernel build and further runs.
   - The copying of roofs (initrd.cpio) occurs only at the BuildSetup stage, when each of the target builds is being set up.

#11 
 
`:)`