### PR TITLE
fix: update the`tpl_app_fs_init.sh` 's test application path

### DIFF
--- a/scripts/tpl_app_fs_init.sh
+++ b/scripts/tpl_app_fs_init.sh
@@ -16,7 +16,7 @@ mkdir "$testing_rootfs"
 if test "$(basename "$init_rootfs")" = "Dockerfile"; then
     image_name="uk-{name}"
     d=$(pwd)
-    cd {init_dir}
+    cd {test_app_dir}
     docker build -o "$testing_rootfs" -f "$init_rootfs" -t "$image_name" .
     cd "$d"
 else

--- a/src/app_config.py
+++ b/src/app_config.py
@@ -277,8 +277,7 @@ class AppConfig:
         else:
             rootfs = ""
         init_dir = os.getcwd()
-
-        # shank: I need to fix this path to my local directory(tester_config.yaml)
+        test_app_dir = os.path.join(init_dir, ".app")
         base = tester_config.config["source"]["base"]
 
         name = self.config["name"]


### PR DESCRIPTION
Populates the `tpl_app_fs_init.sh` differently. It replaces `init_dir` with new variable `test_app_dir`, locating to the correct path for the rootfs.