### PR TITLE
fix: minor run fixs and readme.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,44 @@ This project uses a shell script that requires sudo access. To avoid being promp
 To run the framework, use the following command:
 
 ```console
-./main.sh /absolute/path/to/app/dir
+python src/main.py /absolute/path/to/app/dir
 ```
 
 Make sure the path you provide is absolute (i.e., it starts with /). This should point to the specific application directory inside your catalog repository.
+
+#### Command Line Arguments
+
+The framework supports the following optional arguments:
+
+- **`-n, --test-session-name`**: Specify a custom test session name. If not provided, a 'session' will be used as default name.
+  ```console
+  python src/main.py /absolute/path/to/app/dir -n my_test_session
+  ```
+
+- **`-t, --target-no`**: Run tests for specific targets only. Supports multiple formats:
+  - **Comma-separated**: `1,3,5` - Run targets 1, 3, and 5
+  - **Range with colon**: `1:5` - Run targets 1 through 5
+  - **Range with dash**: `1-5` - Run targets 1 through 5  
+  - **Mixed formats**: `1,3:5,7` - Run target 1, targets 3-5, and target 7
+  - **Space-separated**: `1 3 5` - Run targets 1, 3, and 5
+
+  ```console
+  # Run specific targets
+  python src/main.py /absolute/path/to/app/dir -t 1,3,5
+  
+  # Run a range of targets
+  python src/main.py /absolute/path/to/app/dir -t 1:5
+  
+  # Combined example with custom session name
+  python src/main.py /absolute/path/to/app/dir -n my_session -t 2:4,7
+  ```
+
+- **`-v, --verbose`**: Enable verbose output with debug-level logging.
+  ```console
+  python src/main.py /absolute/path/to/app/dir -v
+  ```
+
+**Note**: Target numbers use 1-based indexing (first target is 1, not 0). If no target numbers are specified, all available targets will be tested.
 
 ## 🤝 Contributing
 

--- a/src/build_setup.py
+++ b/src/build_setup.py
@@ -220,7 +220,7 @@ class BuildSetup:
                 if os.path.basename(self.app_config.config["rootfs"]) == "Dockerfile":
                     rootfs = os.path.join(os.getcwd(), ".app", self.app_config.config["rootfs"])
                 else:
-                    rootfs = os.path.join(self.dir, "rootfs")
+                    rootfs = os.path.join(os.getcwd(), ".app", "rootfs")
                 stream.write(f"rootfs: {rootfs}\n\n")
 
             if self.app_config.config["cmd"]:
@@ -274,7 +274,7 @@ class BuildSetup:
 
         base = self.target_config["base"]
         target_dir = self.dir
-        rootfs = os.path.join(os.getcwd(), self.app_config.config["rootfs"])
+        rootfs = os.path.join(os.getcwd(), ".app", self.app_config.config["rootfs"])
         name = self.app_config.config["name"]
         # (cross_compile, compiler) = self._get_compiler_vars()
         compiler = self.config["compiler"]["path"]
@@ -306,7 +306,7 @@ class BuildSetup:
             raw_content = stream.read()
 
         if self.app_config.config["rootfs"]:
-            rootfs = os.path.join(os.getcwd(), self.app_config.config["rootfs"])
+            rootfs = os.path.join(os.getcwd(), ".app", self.app_config.config["rootfs"])
         else:
             rootfs = ""
         target_dir = self.dir

--- a/src/test_runner.py
+++ b/src/test_runner.py
@@ -388,7 +388,7 @@ class TestRunner(Loggable):
 
         if run_return_code == 0 and output_matched:
             status = "pass"
-        elif run_return_code == 0 and not output_matched:
+        elif (run_return_code == 0 and not output_matched) or (run_return_code != 0 and output_matched):
             status = "partial-pass"
 
         flat_dict = {


### PR DESCRIPTION
This pull request introduces updates to the framework's documentation, improves the handling of root filesystem paths in the build setup, and refines test result reporting. The most significant changes include switching to a Python-based entry point, adding new command-line argument options, updating how root filesystem paths are resolved, and enhancing the logic for test status reporting.

### Documentation and usability enhancements:
* Updated the framework's entry point to use `python src/main.py` instead of a shell script, and added detailed documentation for new optional command-line arguments (`-n`, `-t`, `-v`) in `README.md`. These options improve flexibility by allowing users to customize test session names, specify target tests, and enable verbose logging.

### Build setup improvements:
* Modified multiple methods in `src/build_setup.py` (`_generate_run_kraftfile`, `_generate_build_make_einitrd`, `_generate_build_kraft`) to standardize the resolution of root filesystem paths. All paths now use `.app` as the base directory for consistency and to avoid potential path conflicts. [[1]](diffhunk://#diff-881bb34390ef43c90465462ae5982a93a00aa73cb896214d98f3d45fcedd1304L223-R223) [[2]](diffhunk://#diff-881bb34390ef43c90465462ae5982a93a00aa73cb896214d98f3d45fcedd1304L277-R277) [[3]](diffhunk://#diff-881bb34390ef43c90465462ae5982a93a00aa73cb896214d98f3d45fcedd1304L309-R309)

### Test result reporting:
* Enhanced the `_update_run_report` method in `src/test_runner.py` to classify test results as "partial-pass" when the return code and output matching conditions are mixed (e.g., a non-zero return code with matched output). This provides more nuanced reporting for edge cases.