### PR TITLE
scripts: Use the same path for linker and compiler

### DIFF
--- a/scripts/tpl_build_make.sh
+++ b/scripts/tpl_build_make.sh
@@ -5,4 +5,4 @@ make -f {target_dir}/Makefile distclean
 UK_DEFCONFIG={target_dir}/defconfig make -f {target_dir}/Makefile defconfig
 touch Makefile.uk
 make -f {target_dir}/Makefile prepare
-make CC={compiler} -f {target_dir}/Makefile -j $(nproc)
+make CC={compiler} LD={compiler} -f {target_dir}/Makefile -j $(nproc)

--- a/scripts/tpl_build_make_einitrd.sh
+++ b/scripts/tpl_build_make_einitrd.sh
@@ -5,4 +5,4 @@ make -f {target_dir}/Makefile distclean
 UK_DEFCONFIG={target_dir}/defconfig make -f {target_dir}/Makefile defconfig
 touch Makefile.uk
 make -f {target_dir}/Makefile prepare
-make CC={compiler} -f {target_dir}/Makefile -j $(nproc)
+make CC={compiler} LD={compiler} -f {target_dir}/Makefile -j $(nproc)


### PR DESCRIPTION
Use the `LD` variable to define the linker path when using `make`. Use the same value as the `CC` variable (used to define the compiler). This is required to use the same linker and compiler version. If the version differs, linker errors may appear.