### PR TITLE
feat: initial workflow setup

### DIFF
--- a/.github/workflows/pr-test-receiver.yml
+++ b/.github/workflows/pr-test-receiver.yml
@@ -1,0 +1,38 @@
+name: Testing framework
+on:
+  repository_dispatch:
+    types: [uk_pr_test]
+jobs:
+  pr-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head repo and branch
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.client_payload.pr_head_repo_full_name }}
+          ref: ${{ github.event.client_payload.pr_head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Ensure exact commit is checked out
+        run: |
+          git fetch --no-tags --depth=1 origin ${{ github.event.client_payload.pr_head_sha }}
+          git checkout ${{ github.event.client_payload.pr_head_sha }}
+      - name: Print PR metadata
+        run: |
+          echo "PR Number: ${{ github.event.client_payload.pr_number }}"
+          echo "PR URL: ${{ github.event.client_payload.pr_url }}"
+          echo "PR Title: ${{ github.event.client_payload.pr_title }}"
+          echo "PR Body: ${{ github.event.client_payload.pr_body }}"
+          echo "PR Head Ref: ${{ github.event.client_payload.pr_head_ref }}"
+          echo "PR Head SHA: ${{ github.event.client_payload.pr_head_sha }}"
+          echo "PR Head Repo: ${{ github.event.client_payload.pr_head_repo_full_name }}"
+          echo "PR Is Fork: ${{ github.event.client_payload.pr_is_fork }}"
+          echo "PR Base Ref: ${{ github.event.client_payload.pr_base_ref }}"
+          echo "Sender: ${{ github.event.client_payload.sender_login }}"
+          echo "Action: ${{ github.event.client_payload.action }}"
+          echo "Timestamp: ${{ github.event.client_payload.timestamp }}"
+      - name: Run tests
+        run: |
+          # Replace with your test/build commands
+          echo "Need to implement actual tests here."
+          # Example: pytest, make test, etc.


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate testing for pull requests triggered via repository dispatch events. The workflow is designed to check out the exact pull request commit, print relevant metadata, and serve as a foundation for integrating automated test commands.

New GitHub Actions workflow for PR testing:

* Added `.github/workflows/pr-test-receiver.yml` to define a workflow triggered by the `uk_pr_test` repository dispatch event, enabling automated testing for specific pull requests.

Workflow setup and metadata handling:

* Configured steps to check out the PR head repository and branch, ensuring the exact commit is fetched and checked out for testing.
* Included a step to print detailed pull request metadata, such as PR number, URL, title, body, refs, SHA, repository info, sender, action, and timestamp, for improved traceability and debugging.

Testing placeholder:

* Added a placeholder step for running tests, indicating where actual test or build commands should be implemented in the future.